### PR TITLE
Cycle 2302b

### DIFF
--- a/.github/changelogs/2023.md
+++ b/.github/changelogs/2023.md
@@ -66,3 +66,7 @@ We have made the following changes to ENR sectors:
   - ENR and TMA sector maps updated.
   - Re-export of existing TMA and Procedural Tower bounds to produce a smoother arc (vertex every 5 degrees now.)
   - Slight realignment of the underlying Sector Volume definitions.
+
+### Revision B
+
+The `DefaultJurisdiction.xml` file intoduced in Cycle 2302 was faulting, causing aircraft tags on the ground at NZCH and NZQN to not appear in ADEP windows. We have rolled back to the previous version of this file.

--- a/DefaultJurisdiction.xml
+++ b/DefaultJurisdiction.xml
@@ -1,92 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <DefaultJurisdiction>
-  <!-- Major ADs -->
-
-  <RuleSets>
-
-    <RuleSet Name="AA_DEPS">
+<RuleSets>
+    <RuleSet Name="NZAA_DEPS">
       <Rules>
         <Departure Values="NZAA">
           <Rules>
             <Default>
-              <AssignSector Order="ADEP, ATMA, RAN, OCR" />
+              <AssignSector Order="ADEP, ATMA, AARR"/>
             </Default>
           </Rules>
         </Departure>
       </Rules>
     </RuleSet>
-
-    <RuleSet Name="HN_DEPS">
+    <RuleSet Name="NZWN_DEPS">
       <Rules>
-        <Departure Values="NZHN">
+        <Departure Values="NZWN">
           <Rules>
             <Default>
-              <AssignSector Order="HTMA, RAN, OCR" />
+              <AssignSector Order="WDEP, WTMA"/>
             </Default>
           </Rules>
         </Departure>
       </Rules>
     </RuleSet>
-
-    <RuleSet Name="OH_DEPS">
-      <Rules>
-        <Departure Values="NZOH,NZPM">
-          <Rules>
-            <Default>
-              <AssignSector Order="OTMA, OHA, NAK" />
-            </Default>
-          </Rules>
-        </Departure>
-      </Rules>
-    </RuleSet>
-
-    <RuleSet Name="WN_DEPS">
-      <Rules>
-        <Departure Values="NZWN, NZWB">
-          <Rules>
-            <Default>
-              <AssignSector Order="WDEP, WTMA, NAK" />
-            </Default>
-          </Rules>
-        </Departure>
-
-        <Departure Vales="NZNS">
-          <Rules>
-            <Route Values="SIMZI, LUBSI, LUSRA, ">
-              <AssignSector Order="TNS, WTMA, NAK" />
-            </Route>
-          </Rules>
-
-          <Default>
-            <AssignSector Order="TNS, NAK" />
-          </Default>
-        </Departure>
-      </Rules>
-    </RuleSet>
-
-    <RuleSet Name="CH_DEPS">
+    <RuleSet Name="NZCH_DEPS">
       <Rules>
         <Departure Values="NZCH">
           <Rules>
             <Default>
-              <AssignSector Order="CDEP, CTMA, KAI, STH" />
+              <AssignSector Order="CDEP, CTMA"/>
             </Default>
           </Rules>
         </Departure>
       </Rules>
     </RuleSet>
-
-
-    <RuleSet Name="QN_DEPS">
-      <Rules>
-        <Departure Values="NZQN">
-          <Rules>
-            <Default>
-              <AssignSector Order="QTMA, STH" />
-            </Default>
-          </Rules>
-        </Departure>
-      </Rules>
-    </RuleSet>
-  </RuleSets>
+</RuleSets>
 </DefaultJurisdiction>

--- a/Profile.xml
+++ b/Profile.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Profile Name="New Zealand" FullName="Lockheed Martin SkyLine NZZC">
-	<Version AIRAC="2302" Revision="a" PublishDate="20230223"
+	<Version AIRAC="2302" Revision="b" PublishDate="20230225"
 		UpdateURL="https://vatsys.sawbe.com/downloads/data/New%20Zealand/" />
 	<Servers>
 		<VATSIMStatus url="https://status.vatsim.net/" />


### PR DESCRIPTION
The `DefaultJurisdiction.xml` file intoduced in Cycle 2302 was faulting, causing aircraft tags on the ground at NZCH and NZQN to not appear in ADEP windows. We have rolled back to the previous version of this file.