### PR TITLE
Replace all instances of LAKES with ORIDI and fix YOGIT3C STAR routing

### DIFF
--- a/Airspace.xml
+++ b/Airspace.xml
@@ -6833,7 +6833,7 @@ RILEY
       <Transition Name="IGBAT">KAPAI/IGBAT</Transition>
       <Transition Name="KAPAI">KAPAI</Transition>
       <Transition Name="ORIDI">GULED/OSAKU/ORIDI</Transition>
-      <Transition Name="TULMI">GULED/OSAKU/LAKES/TULMI</Transition>
+      <Transition Name="TULMI">GULED/OSAKU/ORIDI/TULMI</Transition>
     </SID>
     <SID Name="MEMO3P" Airport="NZAA" Runways="23L">
       <Route Runway="23L">LENGU/WYTAK/MEMOR</Route>
@@ -6871,7 +6871,7 @@ RILEY
       <Route Runway="05R">EMRAG/POLIS</Route>
       <Transition Name="IGBAT">LIMES/IGBAT</Transition>
       <Transition Name="KAPAI">KAPAI</Transition>
-      <Transition Name="LAKES">LAKES</Transition>
+      <Transition Name="ORIDI">ORIDI</Transition>
       <Transition Name="TULMI">TULMI</Transition>
     </SID>
     <SID Name="RAXI3Q" Airport="NZAA" Runways="05R">
@@ -8721,7 +8721,7 @@ RILEY
       <Transition Name="TAYLA">TAYLA/CHESE</Transition>
     </STAR>
     <STAR Name="YOGI3C" Airport="NZHN" Runways="18L">
-      <Route Runway="18L">ATPUL/TAYLA/VATNA</Route>
+      <Route Runway="18L">YOGIT/ADBET/VATNA</Route>
       <Transition Name="DABKA">DABKA/BOLOG/EKASO</Transition>
       <Transition Name="DADUK">DADUK/BOLOG/EKASO</Transition>
       <Transition Name="POKOM">POKOM</Transition>

--- a/Maps/NZAA/AA_ACU.xml
+++ b/Maps/NZAA/AA_ACU.xml
@@ -128,8 +128,8 @@
       POLIS/KAPAI
     </Line>
     <Line Pattern="Dashed">
-      <!--Rwy05R POLI3Q.LAKES-->
-      POLIS/LAKES
+      <!--Rwy05R POLI3Q.ORIDI-->
+      POLIS/ORIDI
     </Line>
     <Line Pattern="Dashed">
       <!--Rwy05R POLI3Q.TULMI-->
@@ -248,7 +248,6 @@
       <Point>KADMA</Point>
       <Point>DUGAN</Point>
       <Point>ELNOS</Point>
-      <Point>LAKES</Point>
       <Point>TULMI</Point>
       <Point>RAXIN</Point>
       <Point>AGREX</Point>
@@ -295,7 +294,6 @@
       <Point>PUHOI</Point>
       <Point>DUGAN</Point>
       <Point>ELNOS</Point>
-      <Point>LAKES</Point>
       <Point>TULMI</Point>
       <Point>AGREX</Point>
       <Point>ELPAK</Point>
@@ -730,7 +728,7 @@
     </Line>
     <Line Pattern="Dashed">
       <!--Rwy23L LEVR2P.TULMI-->
-      OSAKU/LAKES/TULMI
+      OSAKU/ORIDI/TULMI
     </Line>
     <Line Pattern="Dashed">
       <!--Rwy23L MEMO3P-->
@@ -867,7 +865,6 @@
       <Point>GULED</Point>
       <Point>OSAKU</Point>
       <Point>ORIDI</Point>
-      <Point>LAKES</Point>
       <Point>TULMI</Point>
       <Point>MEMOR</Point>
       <Point>AGREX</Point>

--- a/Maps/NZHN/HN_ACU.xml
+++ b/Maps/NZHN/HN_ACU.xml
@@ -183,17 +183,19 @@
     </Line>
     <Line Pattern="Solid">
       <!--Rwy18L YOGI3C.DABKA-->
-      EKASO/ATPUL
+     DABKA/BOLOG/EKASO/YOGIT
     </Line>
     <Line Pattern="Solid">
       <!--Rwy18L YOGI3C.DADUK-->
+      DADUK/BOLOG/EKASO/YOGIT
     </Line>
     <Line Pattern="Solid">
       <!--Rwy18L YOGI3C.POKOM-->
-      POKOM/ATPUL
+      POKOM/YOGIT
     </Line>
     <Line>
       <!--Rwy18L YOGI3C-->
+      YOGIT/ADBET/VATNA
     </Line>
     <Symbol Type="HollowTriangle">
       <Point>TAYLA</Point>


### PR DESCRIPTION
Removed all instances of LAKES and replaced with WPT ORIDI in AA.ACU, HN.ACU and Airspace XML files, and fixed the route drawing of the YOGIT3C STAR for HN RWY 18L: